### PR TITLE
Cron patterns have 6 entries - update schema

### DIFF
--- a/schemas/schedule.yml
+++ b/schemas/schedule.yml
@@ -5,6 +5,8 @@ description: |
     If several patterns are specified, tasks will be created at any time
     specified by one or more patterns.
 type: array
+minItems: 6
+maxItems: 6
 items:
   title: "Cron Pattern"
   type: string


### PR DESCRIPTION
Just fixed size of array to 6 for the 6 fields used by https://www.npmjs.com/package/cron-parser.