### PR TITLE
Schema tidy up

### DIFF
--- a/schemas/hook-definition.yml
+++ b/schemas/hook-definition.yml
@@ -11,7 +11,13 @@ properties:
     type:                 string
     maxLength:            255
   metadata:               {$const: metadata}
-  schedule:               {$ref: "http://schemas.taskcluster.net/hooks/v1/schedule.json"}
+  schedule:
+    description: |
+      Definition of the times at which a hook will result in creation of a task.
+      If several patterns are specified, tasks will be created at any time
+      specified by one or more patterns.  Note that tasks may not be created
+      at exactly the time specified.
+                          {$ref: "http://schemas.taskcluster.net/hooks/v1/schedule.json"}
   expires:                {$const: expires}
   deadline:               {$const: deadline}
   task:                   {$ref: "http://schemas.taskcluster.net/queue/v1/create-task-request.json"}

--- a/schemas/schedule.yml
+++ b/schemas/schedule.yml
@@ -1,9 +1,10 @@
 $schema:        http://json-schema.org/draft-04/schema#
-title:          "Hook schedule"
+title:          "Schedule"
 description: |
-    Definition of the times at which a hook will result in creation of a task.
-    If several patterns are specified, tasks will be created at any time
-    specified by one or more patterns.
+    A list of cron-style definitions to represent a set of moments in (UTC) time.
+    If several patterns are specified, a given moment in time represented by
+    more than one pattern is considered only to be counted once, in other words
+    it is allowed for the cron patterns to overlap; duplicates are redundant.
 type: array
 items:
   title: "Cron Pattern"
@@ -12,6 +13,5 @@ items:
       Cron-like specification for when tasks should be created.  The pattern is
       parsed in a UTC context.
       See [cron-parser on npm](https://www.npmjs.com/package/cron-parser).
-      Note that tasks may not be created at exactly the time specified.
 uniqueItems: true
 default: []


### PR DESCRIPTION
These changes are to improve the [generated hooks library code](https://godoc.org/github.com/taskcluster/taskcluster-client-go/hooks#HookSchedule) in taskcluster-client-go.

At the moment we have two schemas with the title `Hook Schedule` which results in generated go types `HookSchedule` and embedded inside it, `HookSchedule1`. I've renamed `HookSchedule1` to `Schedule` and updated description for it to be an abstract schedule (not hook-specific), and that `HookSchedule` now contains the hook-relevant context in its description.

If you take a close look at the godocs, you'll see `HookSchedule.Schedule` doesn't have a description (unlike `HookSchedule.NextScheduledDate`) which is also a reason for moving the description up a level to `HookSchedule`, so that both of its members now have a description, and then inside the new `Schedule` type (that used to be called `HookSchedule1`) the description is now about how it represents a generic (non-hook-specific) schedule.

I wasn't sure how to test my changes, i.e. how to convert the `.yml` files to `.json` and then view the updated docs in a web browser. Maybe we should set up a staging env using [heroku pipelines](https://devcenter.heroku.com/articles/pipelines) and then it would be possible to validate these changes before pushing to production. What do you think? So - to be clear - I haven't worked out how to test that these yml changes result in valid json.