### PR TITLE
Run most tests entirely in-memory unless credentials are available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ services:
 - rabbitmq
 script: npm test
 before_install:
-- openssl aes-256-cbc -K $encrypted_c76f7cd53afb_key -iv $encrypted_c76f7cd53afb_iv -in user-config.yml.enc -out user-config.yml -d
+# unpack the secrets, but only if this is not a pull request; otherwise, the tests will run with no credentials
+- '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && openssl aes-256-cbc -K $encrypted_c76f7cd53afb_key -iv $encrypted_c76f7cd53afb_iv -in user-config.yml.enc -out user-config.yml -d

--- a/bin/main.js
+++ b/bin/main.js
@@ -28,7 +28,7 @@ var load = loader({
         return new base.stats.Influx(cfg.influx)
       } else {
         debug("Not loading Influx -- no connection string");
-        return null;
+        return new base.stats.NullDrain();
       }
     },
   },

--- a/bin/main.js
+++ b/bin/main.js
@@ -12,7 +12,7 @@ var AWS         = require('aws-sdk-promise');
 // These will exist in taskcluster-base, when we move to the next version.
 var config      = require('typed-env-config');
 var loader      = require('taskcluster-lib-loader');
-var tc_lib_app  = require('taskcluster-lib-app');
+var app         = require('taskcluster-lib-app');
 
 // Create component loader
 var load = loader({
@@ -89,9 +89,9 @@ var load = loader({
   server: {
     requires: ['cfg', 'router'],
     setup: ({cfg, router}) => {
-      let app = tc_lib_app(cfg.server);
-      app.use('/v1', router);
-      return app.createServer();
+      let hooksApp = app(cfg.server);
+      hooksApp.use('/v1', router);
+      return hooksApp.createServer();
     },
   },
 

--- a/bin/main.js
+++ b/bin/main.js
@@ -12,6 +12,7 @@ var AWS         = require('aws-sdk-promise');
 // These will exist in taskcluster-base, when we move to the next version.
 var config      = require('typed-env-config');
 var loader      = require('taskcluster-lib-loader');
+var tc_lib_app  = require('taskcluster-lib-app');
 
 // Create component loader
 var load = loader({
@@ -22,7 +23,14 @@ var load = loader({
 
   influx: {
     requires: ['cfg'],
-    setup: ({cfg}) => new base.stats.Influx(cfg.influx),
+    setup: ({cfg}) => {
+      if (cfg.influx && cfg.influx.connectionString) {
+        return new base.stats.Influx(cfg.influx)
+      } else {
+        debug("Not loading Influx -- no connection string");
+        return null;
+      }
+    },
   },
 
   Hook: {
@@ -81,7 +89,7 @@ var load = loader({
   server: {
     requires: ['cfg', 'router'],
     setup: ({cfg, router}) => {
-      let app = base.app(cfg.server);
+      let app = tc_lib_app(cfg.server);
       app.use('/v1', router);
       return app.createServer();
     },

--- a/config.yml
+++ b/config.yml
@@ -62,11 +62,12 @@ test:
     scheduler:
       pollingDelay:   5000
   azureTable:
-    account:          'jungle'
+    # use in-memory fake Azure by default; you can override in user-config.yml
+    # this with a real account together with setting `taskcluster.credentials`
+    # to test against the real Azure Table Storage.
+    account:          'inMemory'
     signingKey:       'not a secret'
     cryptoKey:        'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
-  taskcluster:
-    authBaseUrl:      http://localhost:60407/v1
   server:
     port:             60401
     publicUrl:        'http://localhost:60401'

--- a/hooks/data.js
+++ b/hooks/data.js
@@ -1,4 +1,4 @@
-var base        = require('taskcluster-base');
+var Entity      = require('azure-entities');
 var debug       = require('debug')('hooks:data');
 var assert      = require('assert');
 var Promise     = require('promise');
@@ -6,55 +6,55 @@ var taskcluster = require('taskcluster-client');
 var _           = require('lodash');
 
 /** Entity for tracking hooks and associated state **/
-var Hook = base.Entity.configure({
+var Hook = Entity.configure({
   version:              1,
-  partitionKey:         base.Entity.keys.StringKey('hookGroupId'),
-  rowKey:               base.Entity.keys.StringKey('hookId'),
+  partitionKey:         Entity.keys.StringKey('hookGroupId'),
+  rowKey:               Entity.keys.StringKey('hookId'),
   signEntities:         true,
   properties:           {
-    hookGroupId:        base.Entity.types.String,
-    hookId:             base.Entity.types.String,
-    metadata:           base.Entity.types.JSON,
+    hookGroupId:        Entity.types.String,
+    hookId:             Entity.types.String,
+    metadata:           Entity.types.JSON,
     // task template
-    task:               base.Entity.types.JSON,
+    task:               Entity.types.JSON,
     // pulse bindings (TODO; empty for now)
-    bindings:           base.Entity.types.JSON,
+    bindings:           Entity.types.JSON,
     // timings for the task (in fromNow format, e.g., "1 day")
-    deadline:           base.Entity.types.String,
-    expires:            base.Entity.types.String,
+    deadline:           Entity.types.String,
+    expires:            Entity.types.String,
     // schedule for this task (see schemas/schedule.yml)
-    schedule:           base.Entity.types.JSON,
+    schedule:           Entity.types.JSON,
     // access token used to trigger this task via webhook
-    triggerToken:       base.Entity.types.EncryptedText,
+    triggerToken:       Entity.types.EncryptedText,
     // the taskId that will be used next time this hook is scheduled;
     // this allows scheduling to be idempotent
-    nextTaskId:         base.Entity.types.EncryptedText,
+    nextTaskId:         Entity.types.EncryptedText,
     // next date at which this task is scheduled to run
-    nextScheduledDate:  base.Entity.types.Date,
+    nextScheduledDate:  Entity.types.Date,
   }
 }).configure({
   version:              2,
   signEntities:         true,
   properties:           {
-    hookGroupId:        base.Entity.types.String,
-    hookId:             base.Entity.types.String,
-    metadata:           base.Entity.types.JSON,
+    hookGroupId:        Entity.types.String,
+    hookId:             Entity.types.String,
+    metadata:           Entity.types.JSON,
     // task template
-    task:               base.Entity.types.JSON,
+    task:               Entity.types.JSON,
     // pulse bindings (TODO; empty for now)
-    bindings:           base.Entity.types.JSON,
+    bindings:           Entity.types.JSON,
     // timings for the task (in fromNow format, e.g., "1 day")
-    deadline:           base.Entity.types.String,
-    expires:            base.Entity.types.String,
+    deadline:           Entity.types.String,
+    expires:            Entity.types.String,
     // schedule for this task (see schemas/schedule.yml)
-    schedule:           base.Entity.types.JSON,
+    schedule:           Entity.types.JSON,
     // access token used to trigger this task via webhook
-    triggerToken:       base.Entity.types.EncryptedText,
+    triggerToken:       Entity.types.EncryptedText,
     // the taskId that will be used next time this hook is scheduled;
     // this allows scheduling to be idempotent
-    nextTaskId:         base.Entity.types.EncryptedText,
+    nextTaskId:         Entity.types.EncryptedText,
     // next date at which this task is scheduled to run
-    nextScheduledDate:  base.Entity.types.Date,
+    nextScheduledDate:  Entity.types.Date,
   },
   migrate: function(item) {
     // remove the task timestamps, as they are overwritten when the hook fires
@@ -68,28 +68,28 @@ var Hook = base.Entity.configure({
   version:              3,
   signEntities:         true,
   properties:           {
-    hookGroupId:        base.Entity.types.String,
-    hookId:             base.Entity.types.String,
-    metadata:           base.Entity.types.JSON,
+    hookGroupId:        Entity.types.String,
+    hookId:             Entity.types.String,
+    metadata:           Entity.types.JSON,
     // task template
-    task:               base.Entity.types.JSON,
+    task:               Entity.types.JSON,
     // pulse bindings (TODO; empty for now)
-    bindings:           base.Entity.types.JSON,
+    bindings:           Entity.types.JSON,
     // timings for the task (in fromNow format, e.g., "1 day")
-    deadline:           base.Entity.types.String,
-    expires:            base.Entity.types.String,
+    deadline:           Entity.types.String,
+    expires:            Entity.types.String,
     // schedule for this task (see schemas/schedule.yml)
-    schedule:           base.Entity.types.JSON,
+    schedule:           Entity.types.JSON,
     // access token used to trigger this task via webhook
-    triggerToken:       base.Entity.types.EncryptedText,
+    triggerToken:       Entity.types.EncryptedText,
     // information about the last time this hook fired:
     // {error: ".."} or {taskId: ".."}
-    lastFire:           base.Entity.types.JSON,
+    lastFire:           Entity.types.JSON,
     // the taskId that will be used next time this hook is scheduled;
     // this allows scheduling to be idempotent
-    nextTaskId:         base.Entity.types.EncryptedText,
+    nextTaskId:         Entity.types.EncryptedText,
     // next date at which this task is scheduled to run
-    nextScheduledDate:  base.Entity.types.Date,
+    nextScheduledDate:  Entity.types.Date,
   },
   migrate: function(item) {
     item.lastFire = {result: 'no-fire'};

--- a/hooks/scheduler.js
+++ b/hooks/scheduler.js
@@ -1,6 +1,6 @@
 var assert      = require('assert');
 var events      = require('events');
-var base        = require('taskcluster-base');
+var Entity      = require('azure-entities');
 var data        = require('./data');
 var debug       = require('debug')('hooks:scheduler');
 var Promise     = require('promise');
@@ -71,7 +71,7 @@ class Scheduler extends events.EventEmitter {
   async poll() {
     // Get all hooks that have a scheduled date that is earlier than now
     var hooks = await this.Hook.scan({
-      nextScheduledDate:  base.Entity.op.lessThan(new Date())
+      nextScheduledDate:  Entity.op.lessThan(new Date())
     }, {
       limit: 100,
       handler: (hook) => this.handleHook(hook),

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "assume": "^1.2.5",
     "aws-sdk": "^2.2.0",
     "aws-sdk-promise": "^0.0.2",
+    "azure-entities": "^0.9.0",
     "babel": "^5.8.21",
     "cron-parser": "^1.0.1",
     "debug": "^2.2.0",
@@ -23,7 +24,9 @@
     "taskcluster-base": "^0.8.4",
     "taskcluster-client": "^0.22.4",
     "typed-env-config": "^0.10.0",
-    "taskcluster-lib-loader": "0.0.8"
+    "taskcluster-lib-app": "^0.8.9",
+    "taskcluster-lib-loader": "0.0.8",
+    "taskcluster-lib-testing": "^0.9.2"
   },
   "engines": {
     "node":                 "0.12.x",

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -5,9 +5,7 @@ suite('API', function() {
   var debug       = require('debug')('test:api:createhook');
   var helper      = require('./helper');
 
-  if (!helper.setup()) {
-    this.pending = true;
-  }
+  helper.setup();
 
   // Use the same hook definition for everything
   var hookDef = require('./test_definition');

--- a/test/scheduler_test.js
+++ b/test/scheduler_test.js
@@ -9,11 +9,7 @@ suite('Scheduler', function() {
   var taskcluster       = require('taskcluster-client');
 
   this.slow(500);
-
-  // these tests require Azure credentials (for the Hooks table)
-  if (!helper.setup()) {
-    this.pending = true;
-  }
+  helper.setup();
 
   var scheduler = null;
   var creator = null;

--- a/test/taskcreator_test.js
+++ b/test/taskcreator_test.js
@@ -7,10 +7,10 @@ suite('TaskCreator', function() {
   var taskcluster       = require('taskcluster-client');
 
   this.slow(500);
+  helper.setup();
 
-  // these tests require TaskCluster credentials (for the queue insert)
-  // and to do helper setup (which configures Hooks)
-  if (!helper.setup()) {
+  // these tests require real TaskCluster credentials (for the queue insert)
+  if (!helper.haveRealCredentials) {
     this.pending = true;
   }
 


### PR DESCRIPTION
This uses the new fakeauth as well as the new inMemory azure-entities fake, so that tests talking to those two things can run without any credentials or network access (and very fast!!).

The tests for actually creating a task *do* require credentials.  There are still credentials in the travis-encrypted file to support this.  Let's see if Travis still fails on a PR.

I had to sort of hack out the requirement for an influx connection string.  Hopefully that's OK.