### PR TITLE
Fix link to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A hooks service for triggering tasks from events.
 
 API Documentation
 -----------------
-Please see http://docs.taskcluster.net/services/hooks/.
+Please see https://docs.taskcluster.net/reference/core/hooks/api-docs.
 
 Testing
 -------


### PR DESCRIPTION
I noticed this was broken on https://docs.taskcluster.net/reference/core/hooks , and I assume the content there is generated from this README.md.