### PR TITLE
Enable triggerHook api endpoint

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -335,6 +335,42 @@ api.declare({
   return res.status(200).json({});
 });
 
+/** Trigger a hook **/
+api.declare({
+  method:       'post',
+  route:        '/hooks/:hookGroupId/:hookId/trigger',
+  name:         'triggerHook',
+  deferAuth:    true,
+  scopes:       [["hooks:trigger-hook:<hookGroupId>/<hookId>"]],
+  input:        'trigger-payload.json',
+  output:       'task-status.json',
+  title:        'Trigger a hook',
+  stability:    'experimental',
+  description: [
+    "This endpoint will trigger the creation of a task from a hook definition."
+  ].join('\n')
+}, async function(req, res) {
+  var hookGroupId = req.params.hookGroupId;
+  var hookId    = req.params.hookId;
+  if (!req.satisfies({hookGroupId, hookId})) {
+    return;
+  }
+
+  var payload = req.body;
+
+  var hook = await this.Hook.load({hookGroupId, hookId}, true);
+
+  // Return a 404 if the hook entity doesn't exist
+  if (!hook) {
+    return res.status(404).json({
+      message: "Hook not found"
+    });
+  }
+
+  let resp = await this.taskcreator.fire(hook, payload);
+  return res.reply(resp);
+});
+
 // XXX disabled for the first draft of this service
 if (0) {
 
@@ -444,43 +480,6 @@ api.declare({
   if (req.params.token !== hook.triggerToken) {
     return res.status(401).json({
       message: "Invalid token"
-    });
-  }
-
-  let resp = await this.taskcreator.fire(hook, payload);
-  return res.reply(resp);
-});
-
-
-/** Trigger a hook for debugging **/
-api.declare({
-  method:       'post',
-  route:        '/hooks/:hookGroupId/:hookId/trigger',
-  name:         'triggerHook',
-  deferAuth:    true,
-  scopes:       [["hooks:trigger-hook:<hookGroupId>/<hookId>"]],
-  input:        'trigger-payload.json',
-  output:       'task-status.json',
-  title:        'Trigger a hook',
-  stability:    'experimental',
-  description: [
-    "Trigger a hook, given that you have the correct scoping for it"
-  ].join('\n')
-}, async function(req, res) {
-  var hookGroupId = req.params.hookGroupId;
-  var hookId    = req.params.hookId;
-  if (!req.satisfies({hookGroupId, hookId})) {
-    return;
-  }
-
-  var payload = req.body;
-
-  var hook = await this.Hook.load({hookGroupId, hookId}, true);
-
-  // Return a 404 if the hook entity doesn't exist
-  if (!hook) {
-    return res.status(404).json({
-      message: "Hook not found"
     });
   }
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -205,6 +205,14 @@ suite('API', function() {
       assume(r1.lastFire.time).is.equal(now.toJSON());
     });
 
+    test("returns the last run status for triggerHook", async() => {
+      await helper.hooks.createHook('foo', 'bar', hookDef);
+      await helper.hooks.triggerHook('foo', 'bar', {a: "payload"});
+      var r1 = await helper.hooks.getHookStatus('foo', 'bar');
+      assume(r1).contains('lastFire');
+      assume(r1.lastFire.result).is.equal('success');
+    });
+
     test("fails if no hook exists", async () => {
       await helper.hooks.getHookStatus('foo', 'bar').then(
           () => { throw new Error("The resource should not exist"); },

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -212,6 +212,33 @@ suite('API', function() {
     });
   });
 
+  suite("triggerHook", function() {
+    test("should launch task with the given payload", async () => {
+      await helper.hooks.createHook('foo', 'bar', hookDef);
+      await helper.hooks.triggerHook('foo', 'bar', {a: "payload"});
+      assume(helper.creator.fireCalls).deep.equals([{
+          hookGroupId: 'foo',
+          hookId: 'bar',
+          payload: {a: "payload"},
+          options: {}
+        }]);
+    });
+
+    test("with invalid scopes", async () => {
+      await helper.hooks.createHook('foo', 'bar', hookDef);
+      helper.scopes('hooks:trigger-hook:wrong/scope');
+      await helper.hooks.triggerHook('foo', 'bar', {a: "payload"}).then(
+          () => { throw new Error("Expected an authentication error"); },
+          (err) => { debug("Got expected authentication error: %s", err); });
+    });
+
+    test("fails if no hook exists", async () => {
+      await helper.hooks.triggerHook('foo', 'bar', {a: "payload"}).then(
+          () => { throw new Error("The resource should not exist"); },
+          (err) => { assume(err.statusCode).equals(404); });
+    });
+  });
+
   suite("resetTriggerToken", function() {
     // XXX disabled for the first draft of this service
     this.pending = true;
@@ -223,22 +250,6 @@ suite('API', function() {
       assume(r1).deep.not.equals(r2);
       var r3 = await helper.hooks.getTriggerToken('foo', 'bar');
       assume(r2).deep.equals(r2);
-    });
-  });
-
-  suite("triggerHook", function() {
-    // XXX disabled for the first draft of this service
-    this.pending = true;
-
-    test("should launch task with the given payload", async () => {
-      await helper.hooks.createHook('foo', 'bar', hookDef);
-      await helper.hooks.triggerHook('foo', 'bar', {a: "payload"});
-      assume(helper.creator.fireCalls).deep.equals([{
-          hookGroupId: 'foo',
-          hookId: 'bar',
-          payload: {a: "payload"},
-          options: {}
-        }]);
     });
   });
 


### PR DESCRIPTION
This patch addresses a portion [bug 1286979](https://bugzilla.mozilla.org/show_bug.cgi?id=1286979) by enabling triggerHook for scope-enabled requests. This will allow people to trigger hooks manually through the hook web interface.