### PR TITLE
Bug 1324807 - tempelating system for injecting arbitrary webhook payl…

### DIFF
--- a/tempelate_engine/tempelate_engine.js
+++ b/tempelate_engine/tempelate_engine.js
@@ -1,0 +1,89 @@
+/*
+*========usage=========
+*body = {
+*  name: "Jim",
+*  id: "123",
+*  token: "abc",
+*  tasks: ["enter", "exit"]
+*}
+*
+*tempelate = {
+*  username: "{{payload.name}}",
+*  clientId: "{{payload.id}}",
+*  accessToken: "{{payload.token}}",
+*  task: "payload.tasks.0"
+*}
+*
+*context = {payload: body}
+*
+*engine = new TempelateEngine(tempelate, context);
+*engine.render();
+*engine.getTempelate() // returns rendered tempelete
+*
+*/
+
+class TempelateEngine {
+	
+	constructor(tempelate, context) {
+		this.tempelate = tempelate;
+		this.context = context;
+	}
+
+	/* public */
+	render() {
+		this._render(this.tempelate)
+	}
+
+	/* private */
+	_render(tempelate) {
+		for (var key in tempelate) {
+			if (tempelate.hasOwnProperty(key)) {
+				var value = tempelate[key];
+				if (typeof value === 'string' || value instanceof String) {
+					tempelate[key] = this._replace(tempelate[key]);
+				} else {
+					this._render(tempelate[key]);
+				}
+			}
+		}
+	}
+
+	/* private */
+	_replace(parameterizedString) {
+		var match = this.PARSEEXPR.exec(parameterizedString);
+		if (match) {
+			var replacementValue = this._fetchContextPropertyValue(match[1]);
+			if (match[0] === parameterizedString) {
+				return replacementValue;
+			} else {
+				return parameterizedString.replace(this.PARSEEXPR, replacementValue);
+			}
+			return replacementValue;
+		}
+		return parameterizedString;
+	}
+
+	/* private */
+	_fetchContextPropertyValue(propertyString) {
+		var propertyString = propertyString.trim();
+		var keys = propertyString.split(".");
+		var result = this.context;
+
+		for (var key in keys) {
+			if (keys.hasOwnProperty(key)) {
+				result = result[keys[key]];
+			}
+		}
+
+		return result;
+	}
+
+	/* public */
+	getTempelate() {
+		return this.tempelate;
+	}
+};
+
+TempelateEngine.prototype.PARSEEXPR = /{{(\s*([\d\w]+\b.?\b)+\s*)}}/;
+
+module.exports = TempelateEngine;

--- a/test/tempelate_engine_test.js
+++ b/test/tempelate_engine_test.js
@@ -1,0 +1,65 @@
+suite("TempelateEngine", function() {
+	var TempelateEngine = require("../tempelate_engine/tempelate_engine.js");
+	var assume      = require('assume');
+
+	suite("non nested propert access", function () {
+		test("with propert access", async () => {
+			let tempelate = { id: "{{ clientId }}" };
+			let context = { clientId: "123"};
+			let engine = new TempelateEngine(tempelate, context);
+			engine.render();
+			assume(engine.getTempelate()).deep.equals({id: "123"});
+		});
+
+		test("with index access", async () => {
+			let tempelate = { id: "{{ 0 }}", name: "{{ 2 }}", count: "{{ 1 }}" };
+			let context = ["123", 248, "doodle"];
+			let engine = new TempelateEngine(tempelate, context);
+			engine.render();
+			assume(engine.getTempelate()).deep.equals({id: "123", name: "doodle", count: 248});	
+		});
+	});
+
+	suite("nested property access", function () {
+		test("with property access", async () => {
+			let tempelate = {"task": {
+				taskName: "{{ payload.name }}",
+				workers: "{{ payload.workers }}"
+			}};
+			let context = { payload: {
+				name: "foo",
+				workers: ["worker1", "worker2", "worker3"]
+			}};
+			let engine = new TempelateEngine(tempelate, context);
+			engine.render();
+			assume(engine.getTempelate()).deep.equals({
+				"task": {
+					taskName: context.payload.name,
+					workers: context.payload.workers
+				}});
+		});
+
+		test("with index access", async() => {
+			let tempelate = {a:{b:{c:"{{ payload.a.b.c.1 }}"}}}
+			let context = {payload:{a:{b:{c:[1,2,3]}}}};
+			let engine = new TempelateEngine(tempelate, context);
+			engine.render();
+			assume(engine.getTempelate()).deep.equals({a:{b:{c:2}}});
+		});
+
+		test("with multiple context properties", async() => {
+			let tempelate = {
+				a: "{{ payload.a.b.c }}",
+				b: "{{ header.a.b.c }}"
+			};
+			let context = {
+				payload: {a:{b:{c:1}}},
+				header: {a:{b:{c:1}}}
+			};
+			let engine = new TempelateEngine(tempelate, context);
+			engine.render();
+			assume(engine.getTempelate()).deep.equals({a: 1, b: 1});
+		});
+	});
+
+});


### PR DESCRIPTION
> I have implemented basic functionality for a template engine.

> It doesn't support  something like "{{payload.a.b.c}} {{payload.e.f.g}}" i.e is multiple parameters in a single string (at least for now).

> Do we need support for functions ?