### PR TITLE
Fix error handling when task cannot be created

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -402,20 +402,16 @@ api.declare({
       error: err,
       time: new Date(),
     };
+    return res.status(400).json({
+      error: "could not create task: " + err.toString()
+    });
   }
 
   await hook.modify((hook) => {
     hook.lastFire = lastFire;
   });
 
-
-  if (resp) {
-    return res.reply(resp);
-  } else {
-    return res.status(400).json({
-      error: "could not create task: " + err.toString()
-    });
-  }
+  return res.reply(resp);
 });
 
 /** Get secret token for a trigger **/

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -254,16 +254,18 @@ suite('API', function() {
         }]);
     });
 
-    test("with invalid scopes", async () => {
+    test("fails when creating the task fails", async () => {
       await helper.hooks.createHook('foo', 'bar', hookDef);
-      helper.scopes('hooks:trigger-hook:wrong/scope');
-      await helper.hooks.triggerHook('foo', 'bar', {a: "payload"}).then(
-        (resp) => {
-          assume(resp.statusCode).exists();
-          assume(resp.statusCode).equals(400);
-          assume(resp.error).exists();
-        },
-        (err) => { debug("Got expected authentication error: %s", err); });
+      helper.creator.shouldFail = true; // firing the hook should fail..
+      helper.scopes('hooks:trigger-hook:foo/bar');
+      try {
+        await helper.hooks.triggerHook('foo', 'bar', {a: "payload"});
+      } catch (err) {
+        assume(err.statusCode).equals(400);
+        assume(err.body.error).exists();
+        return;
+      }
+      throw new Error('should have thrown an exception');
     });
 
     test("fails if no hook exists", async () => {

--- a/test/helper.js
+++ b/test/helper.js
@@ -71,6 +71,7 @@ helper.setup = function() {
     await helper.Hook.scan({}, {handler: hook => hook.remove()});
 
     // reset the list of fired tasks
+    helper.creator.shouldFail = false;
     helper.creator.fireCalls = [];
 
     // Setup client with all scopes


### PR DESCRIPTION
Fixes:
```
ReferenceError: err is not defined
  File "/app/routes/v1.js", line 416, in Object.callee$0$0$
    error: "could not create task: " + err.toString()
```

@hammad13060 - r?