### PR TITLE
Fix missing err in error

### DIFF
--- a/routes/v1.js
+++ b/routes/v1.js
@@ -382,6 +382,7 @@ api.declare({
   var resp;
   var payload = req.body;
   var hook = await this.Hook.load({hookGroupId, hookId}, true);
+  var error = null;
 
   if (!hook) {
     return res.status(404).json({
@@ -397,6 +398,7 @@ api.declare({
       time: new Date(),
     };
   } catch(err) {
+    error = err;
     lastFire = {
       result: 'error',
       error: err,
@@ -413,7 +415,7 @@ api.declare({
     return res.reply(resp);
   } else {
     return res.status(400).json({
-      error: "could not create task: " + err.toString()
+      error: "could not create task: " + (error || "unknown").toString()
     });
   }
 });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -254,16 +254,18 @@ suite('API', function() {
         }]);
     });
 
-    test("with invalid scopes", async () => {
+    test("fails when creating the task fails", async () => {
       await helper.hooks.createHook('foo', 'bar', hookDef);
-      helper.scopes('hooks:trigger-hook:wrong/scope');
-      await helper.hooks.triggerHook('foo', 'bar', {a: "payload"}).then(
-        (resp) => {
-          assume(resp.statusCode).exists();
-          assume(resp.statusCode).equals(400);
-          assume(resp.error).exists();
-        },
-        (err) => { debug("Got expected authentication error: %s", err); });
+      helper.creator.shouldFail = true; // firing the hook should fail..
+      helper.scopes('hooks:trigger-hook:foo/bar');
+      try {
+        await helper.hooks.triggerHook('foo', 'bar', {a: "payload"});
+      } catch (err) {
+        assume(err.statusCode).equals(400);
+        assume(err.body.error).exists();
+        return;
+      }
+      throw new Error('should have thrown an exception');
     });
 
     test("fails if no hook exists", async () => {

--- a/test/helper.js
+++ b/test/helper.js
@@ -73,6 +73,8 @@ helper.setup = function() {
     // reset the list of fired tasks
     helper.creator.fireCalls = [];
 
+    helper.creator.shouldFail = false;
+
     // Setup client with all scopes
     helper.scopes();
   });


### PR DESCRIPTION
@hammad13060: An error popped up in Sentry about `err` not being defined here. I've tried to make it defined without changing the initial logic a whole lot. If there is a better way to make this nice, let me know and we can do that instead. For now, if this looks good to you, we can merge it!

Error from Sentry:
```
ReferenceError: err is not defined
  File "/app/routes/v1.js", line 416, in Object.callee$0$0$
    error: "could not create task: " + err.toString()
  File "/app/node_modules/babel/node_modules/babel-core/node_modules/regenerator/runtime.js", line 61, in tryCatch
    return { type: "normal", arg: fn.call(obj, arg) };
  File "[as _invoke] (/app/node_modules/babel/node_modules/babel-core/node_modules/regenerator/runtime.js", line 323, in GeneratorFunctionPrototype.invoke
  File "function) [as next] (/app/node_modules/babel/node_modules/babel-core/node_modules/regenerator/runtime.js", line 94, in GeneratorFunctionPrototype.prototype.(anonymous
  File "/app/node_modules/babel/node_modules/babel-core/node_modules/regenerator/runtime.js", line 132, in GeneratorFunctionPrototype.invoke
    var result = generator[method](arg);
  File "internal/process/next_tick.js", line 129, in process._tickDomainCallback
```