### PR TITLE
fix the test of the MockTaskCreator

### DIFF
--- a/test/taskcreator_test.js
+++ b/test/taskcreator_test.js
@@ -24,7 +24,6 @@ suite('TaskCreator', function() {
    */
 
   var creator = null;
-  var hookDef = require('./test_definition');
 
   setup(async () => {
     creator = await helper.load('taskcreator', helper.loadOptions);
@@ -90,14 +89,19 @@ suite('MockTaskCreator', function() {
   var taskcreator       = require('../hooks/taskcreator');
   var debug             = require('debug')('test:test_schedule_hooks');
   var helper            = require('./helper');
+  var hookDef           = require('./test_definition');
+  var _                 = require('lodash');
 
   var creator = null;
   setup(async () => {
     creator = new taskcreator.MockTaskCreator();
   });
 
-  test("the fire method records calls", async function() {
-    creator.fire({hookGroupId: 'g', hookId: 'h'}, {p: 1}, {o: 1});
+  test('the fire method records calls', async function() {
+    let hook = _.cloneDeep(hookDef);
+    hook.hookGroupId = 'g';
+    hook.hookId = 'h';
+    await creator.fire(hook, {p: 1}, {o: 1});
     assume(creator.fireCalls).deep.equals([
       {hookGroupId: 'g', hookId: 'h', payload: {p: 1}, options: {o: 1}}
     ]);


### PR DESCRIPTION
This wasn't using `await`, so while it was failing, that error was never
seen except in a log to stderr now that we run node 6..

The issue was that the hook definition lacked some fields that the fire method was returning.