### PR TITLE
Don't pass deprecated options to azure-entities constructor

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -39,8 +39,6 @@ var load = loader({
       return data.Hook.setup(_.defaults({
         table:        cfg.app.hookTable,
         monitor:      monitor.prefix(cfg.app.hookTable.toLowerCase()),
-        component:    cfg.app.component,
-        process,
       }, cfg.azureTable, cfg.taskcluster));
     },
   },


### PR DESCRIPTION
Since we use tc-lib-monitor, we don't need these arguments.