### PR TITLE
Enable a docs link at the root URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "promise": "^8.0.1",
     "taskcluster-client": "^3.1.1",
     "taskcluster-lib-api": "^4.0.1",
-    "taskcluster-lib-app": "^2.1.0",
+    "taskcluster-lib-app": "3.0.0",
     "taskcluster-lib-docs": "^4.0.0",
     "taskcluster-lib-loader": "2.0.0",
     "taskcluster-lib-monitor": "^4.3.4",

--- a/src/main.js
+++ b/src/main.js
@@ -103,7 +103,16 @@ var load = loader({
   server: {
     requires: ['cfg', 'router', 'docs'],
     setup: ({cfg, router, docs}) => {
-      let hooksApp = app(cfg.server);
+      let hooksApp = app({
+        port:                   cfg.server.port,
+        env:                    cfg.server.env,
+        forceSSL:               cfg.server.forceSSL,
+        trustProxy:             cfg.server.trustProxy,
+        contentSecurityPolicy:  cfg.server.contentSecurityPolicy,
+        robotstxt:              cfg.server.robotstxt,
+        rootDocsRedirect:       true, 
+        docs,
+      });
       hooksApp.use('/v1', router);
       return hooksApp.createServer();
     },

--- a/src/main.js
+++ b/src/main.js
@@ -108,8 +108,7 @@ var load = loader({
         env:                    cfg.server.env,
         forceSSL:               cfg.server.forceSSL,
         trustProxy:             cfg.server.trustProxy,
-        contentSecurityPolicy:  cfg.server.contentSecurityPolicy,
-        robotstxt:              cfg.server.robotstxt,
+        publicUrl:              cfg.server.publicUrl,
         rootDocsRedirect:       true, 
         docs,
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,9 +2500,9 @@ taskcluster-lib-api@^4.0.1:
     type-is "^1.6.15"
     uuid "^3.1.0"
 
-taskcluster-lib-app@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-app/-/taskcluster-lib-app-2.1.0.tgz#21f0b4e112cd26c2ebf5e6db9401d63091bd2a5f"
+taskcluster-lib-app@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-app/-/taskcluster-lib-app-3.0.0.tgz#bcdb50061f955f8315feed83d3acb9a72e6010c8"
   dependencies:
     babel-runtime "^6.26.0"
     content-security-policy "^0.3.0"


### PR DESCRIPTION
Taskcluster-lib-app now supports generating a link to the documentation, and requires the `docs` object to do so, so pass that to its constructor.