### PR TITLE
Use the right property name to detect real credentials

### DIFF
--- a/test/schedule_hooks_test.js
+++ b/test/schedule_hooks_test.js
@@ -4,7 +4,7 @@ suite('bin/schedule-hooks.js', function() {
   var helper            = require('./helper');
 
   // these tests require Azure credentials (for the Hooks table)
-  if (!helper.hasTcCredentials) {
+  if (!helper.haveRealCredentials) {
     this.pending = true;
   }
 


### PR DESCRIPTION
I assume this was an error on my part in trying to make the tests
pending when there are no credentials.