### PR TITLE
Changed rootDocsRedirect to rootDocsLink

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -109,7 +109,7 @@ var load = loader({
         forceSSL:               cfg.server.forceSSL,
         trustProxy:             cfg.server.trustProxy,
         publicUrl:              cfg.server.publicUrl,
-        rootDocsRedirect:       true, 
+        rootDocsLink:           true, 
         docs,
       });
       hooksApp.use('/v1', router);


### PR DESCRIPTION
Changed rootDocsRedirect to rootDocsLink as it is being used as rootDocsLink in tc-lib-app