### PR TITLE
triggerSchema default in createHook

### DIFF
--- a/schemas/create-hook-request.yml
+++ b/schemas/create-hook-request.yml
@@ -31,7 +31,8 @@ properties:
   deadline:               {$const: deadline}
   task:                   {$ref: "http://schemas.taskcluster.net/hooks/v1/task-template.json"}
   triggerSchema:
-    type:                 object
+    type:                 'object'          
+    default:              {type: "object", additionalProperties: false}
 additionalProperties:     false
 required:
   - metadata

--- a/src/v1.js
+++ b/src/v1.js
@@ -230,7 +230,6 @@ api.declare({
         '{{message}} in {{schedule}}', {message: err.message, schedule});
     }
   });
-
   // Try to create a Hook entity
   try {
     var hook = await this.Hook.create(


### PR DESCRIPTION
@imbstack I put an empty triggerSchema by default in hookDef that doesn't have one and it seems to solve the problem. What do you think about? 