### PR TITLE
Document use of JSON-e, make it more consistent

### DIFF
--- a/docs/firing-hooks.md
+++ b/docs/firing-hooks.md
@@ -40,7 +40,7 @@ against the hook's `triggerSchema`, and supplied in the JSON-e context as
 ```
 {
     firedBy: "triggerHook",
-    context: {..}               // API call payload
+    payload: {..}               // API call payload
 }
 ```
 

--- a/docs/firing-hooks.md
+++ b/docs/firing-hooks.md
@@ -48,7 +48,19 @@ The schema validation also applies any default values specified in the schema.
 
 ### Webhooks
 
-Not yet implemented (context is `{}`)
+Webhooks are invoked with the `triggerHookWithToken` API method. This method is
+designed to be easy to configure with other services like Github.  It requires
+no authentication, but includes a secret token in the URL to prevent
+unauthorized calls to the endpoint.
+
+The context is similar to that for `triggerHook`:
+
+```
+{
+    firedBy: "triggerHookWithToken",
+    payload: {..}               // API call payload
+}
+```
 
 ## Task Times
 

--- a/docs/firing-hooks.md
+++ b/docs/firing-hooks.md
@@ -23,7 +23,13 @@ depending on this property.
 
 ### Scheduled Tasks
 
-Not yet implemented (context is `{}`)
+When a hook is fired at a scheduled time, the JSON-e context is simply:
+
+```
+{
+    firedBy' 'schedule'
+}
+```
 
 ### TriggerHook
 

--- a/docs/firing-hooks.md
+++ b/docs/firing-hooks.md
@@ -17,7 +17,7 @@ submits it to the Queue service via `Queue.createTask`.
 A hook definition's `task` property is, in fact, a [JSON-e](https://taskcluster.github.io/json-e/) template.
 When a hook is fired, that template is rendered and the result is submitted to `Queue.createTask`.
 
-The context for that rendering is an object with property `triggeredBy`, giving
+The context for that rendering is an object with property `firedBy`, giving
 the action that led to the hook firing. The other properties of the object vary
 depending on this property.
 
@@ -33,7 +33,7 @@ against the hook's `triggerSchema`, and supplied in the JSON-e context as
 
 ```
 {
-    triggeredBy: "triggerHook",
+    firedBy: "triggerHook",
     context: {..}               // API call payload
 }
 ```

--- a/docs/firing-hooks.md
+++ b/docs/firing-hooks.md
@@ -1,0 +1,51 @@
+---
+title: Firing Hooks
+order: 10
+---
+
+A hook can be "fired" in a variety of ways:
+
+ * on a schedule
+ * via the `triggerHook` API method
+ * via a webhook, utilizing a security token
+
+In each case, the hooks service creates a task based on the hook definition and
+submits it to the Queue service via `Queue.createTask`.
+
+## JSON-e Rendering
+
+A hook definition's `task` property is, in fact, a [JSON-e](https://taskcluster.github.io/json-e/) template.
+When a hook is fired, that template is rendered and the result is submitted to `Queue.createTask`.
+
+The context for that rendering is an object with property `triggeredBy`, giving
+the action that led to the hook firing. The other properties of the object vary
+depending on this property.
+
+### Scheduled Tasks
+
+Not yet implemented (context is `{}`)
+
+### TriggerHook
+
+Calls to the `triggerHook` method include a payload. The payload is validated
+against the hook's `triggerSchema`, and supplied in the JSON-e context as
+`context`:
+
+```
+{
+    triggeredBy: "triggerHook",
+    context: {..}               // API call payload
+}
+```
+
+The schema validation also applies any default values specified in the schema.
+
+### Webhooks
+
+Not yet implemented (context is `{}`)
+
+## Task Times
+
+The `created`, `deadline`, and `expires` attributes of the task are set
+automatically, based on the relative times in `hook.deadline` and
+`hook.expires`.

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -97,7 +97,7 @@ class Scheduler extends events.EventEmitter {
     var lastFire;
     console.log('firing hook %s/%s with taskId %s', hook.hookGroupId, hook.hookId, hook.nextTaskId);
     try {
-      await this.taskcreator.fire(hook, {}, {
+      await this.taskcreator.fire(hook, {firedBy: 'schedule'}, {
         taskId: hook.nextTaskId,
         // use the next scheduled date as task.created, to ensure idempotency
         created: hook.nextScheduledDate,

--- a/src/taskcreator.js
+++ b/src/taskcreator.js
@@ -72,7 +72,7 @@ class MockTaskCreator extends TaskCreator {
     this.fireCalls = [];
   }
 
-  async fire(hook, payload, options) {
+  async fire(hook, context, options) {
     if (this.shouldFail) {
       let err = new Error('uhoh');
       err.statusCode = 499;
@@ -83,7 +83,7 @@ class MockTaskCreator extends TaskCreator {
     this.fireCalls.push({
       hookGroupId: hook.hookGroupId,
       hookId: hook.hookId,
-      payload,
+      context,
       options});
     var taskId = options.taskId || taskcluster.slugid();
     return {

--- a/src/v1.js
+++ b/src/v1.js
@@ -379,7 +379,7 @@ api.declare({
   } 
   // build the context for the task creation
   let context = {
-    triggeredBy: 'triggerHook',
+    firedBy: 'triggerHook',
     context: payload,
   };
 

--- a/src/v1.js
+++ b/src/v1.js
@@ -26,11 +26,9 @@ var api = new API({
     ' * `[\'0 0 1 * * *\']` -- daily at 1:00 UTC',
     ' * `[\'0 0 9,21 * * 1-5\', \'0 0 12 * * 0,6\']` -- weekdays at 9:00 and 21:00 UTC, weekends at noon',
     '',
-    'Hooks can be parametrized using JSON-e. The task definition in the hook is used as a JSON-e template,',
-    'and the paramters are supplied as a JSON-e context. The result of rendeting the template and context is',
-    'used as the task definition. Currently context can only be provided with the triggerHook method.',
-    'You can find a complete description about how json-e works, here:',
-    'https://github.com/taskcluster/json-e',
+    'The task definition is used as a JSON-e template, with a context depending on how it is fired.  See',
+    'https://docs.taskcluster.net/reference/core/taskcluster-hooks/docs/firing-hooks',
+    'for more information.',
   ].join('\n'),
   schemaPrefix:  'http://schemas.taskcluster.net/hooks/v1/',
 });
@@ -349,6 +347,10 @@ api.declare({
   stability:    'experimental',
   description: [
     'This endpoint will trigger the creation of a task from a hook definition.',
+    '',
+    'The HTTP payload must match the hook\s `triggerSchema`.  If it does, it is',
+    'provided as the `context` property of the JSON-e context used to render the',
+    'task template.',
   ].join('\n'),
 }, async function(req, res) {
   var hookGroupId = req.params.hookGroupId;

--- a/src/v1.js
+++ b/src/v1.js
@@ -384,7 +384,7 @@ api.declare({
   };
 
   try {
-    resp = await this.taskcreator.fire(hook, payload);
+    resp = await this.taskcreator.fire(hook, context);
     lastFire = {
       result: 'success',
       taskId: resp.status.taskId,

--- a/src/v1.js
+++ b/src/v1.js
@@ -349,7 +349,7 @@ api.declare({
     'This endpoint will trigger the creation of a task from a hook definition.',
     '',
     'The HTTP payload must match the hook\s `triggerSchema`.  If it does, it is',
-    'provided as the `context` property of the JSON-e context used to render the',
+    'provided as the `payload` property of the JSON-e context used to render the',
     'task template.',
   ].join('\n'),
 }, async function(req, res) {
@@ -380,7 +380,7 @@ api.declare({
   // build the context for the task creation
   let context = {
     firedBy: 'triggerHook',
-    context: payload,
+    payload: payload,
   };
 
   try {

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -9,8 +9,22 @@ suite('API', function() {
 
   // Use the same hook definition for everything
   var hookDef = require('./test_definition');
-  let hookWithTriggerSchema = _.defaults({triggerSchema: {type: 'object', properties:{location:{type: 'string', 
-    default: 'Niskayuna, NY'}, otherVariable: {type: 'number', default: '12'}}, additionalProperties: true}}, hookDef);
+  let hookWithTriggerSchema = _.defaults({
+    triggerSchema: {
+      type: 'object',
+      properties: {
+        location: {
+          type: 'string',
+          default: 'Niskayuna, NY',
+        },
+        otherVariable: {
+          type: 'number',
+          default: '12',
+        },
+      },
+      additionalProperties: true,
+    },
+  }, hookDef);
 
   let dailyHookDef = _.defaults({
     schedule: ['0 0 3 * * *'],
@@ -314,11 +328,11 @@ suite('API', function() {
     test('successfully triggers task with the given payload', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
       var res = await helper.hooks.getTriggerToken('foo', 'bar');
-      await helper.hooks.triggerHookWithToken('foo', 'bar', res.token, {a: 'payload'});
+      await helper.hooks.triggerHookWithToken('foo', 'bar', res.token, {location: 'New Zealand'});
       assume(helper.creator.fireCalls).deep.equals([{
         hookGroupId: 'foo',
         hookId: 'bar',
-        context: {a: 'payload'},
+        context: {firedBy: 'triggerHookWithToken', payload: {location: 'New Zealand'}},
         options: {},
       }]);
     });
@@ -362,7 +376,7 @@ suite('API', function() {
       assume(helper.creator.fireCalls).deep.equals([{
         hookGroupId: 'foo',
         hookId: 'bar',
-        context: payload,
+        context: {firedBy: 'triggerHookWithToken', payload},
         options: {},
       }]);
     });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -234,7 +234,7 @@ suite('API', function() {
     test('returns the last run status for triggerHook', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
       await helper.hooks.triggerHook('foo', 'bar', {location: 'Belo Horizonte, MG', 
-        firedBy: 'triggerHook'});
+        foo: 'triggerHook'});
       var r1 = await helper.hooks.getHookStatus('foo', 'bar');
       assume(r1).contains('lastFire');
       assume(r1.lastFire.result).is.equal('success');
@@ -251,11 +251,11 @@ suite('API', function() {
     test('should launch task with the given payload', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
       await helper.hooks.triggerHook('foo', 'bar', {location: 'Belo Horizonte, MG', 
-        firedBy: 'triggerHook'});
+        foo: 'triggerHook'});
       assume(helper.creator.fireCalls).deep.equals([{
         hookGroupId: 'foo',
         hookId: 'bar',
-        payload: {location: 'Belo Horizonte, MG', firedBy: 'triggerHook'},
+        payload: {firedBy: 'triggerHook', context: {location: 'Belo Horizonte, MG', foo: 'triggerHook'}},
         options: {},
       }]);
     });
@@ -263,7 +263,7 @@ suite('API', function() {
     test('checking schema validation', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
       await helper.hooks.triggerHook('foo', 'bar', {location: 28, 
-        firedBy: 'triggerHook'}).then(() => { throw new Error('Location type should be string'); },
+        foo: 'triggerHook'}).then(() => { throw new Error('Location type should be string'); },
         (err) => { assume(err.statusCode).equals(400); });
     });
 
@@ -273,7 +273,7 @@ suite('API', function() {
       helper.scopes('hooks:trigger-hook:foo/bar');
       try {
         await helper.hooks.triggerHook('foo', 'bar', {context: {location: 'Belo Horizonte, MG'}, 
-          firedBy: 'triggerHook'});
+          foo: 'triggerHook'});
       } catch (err) {
         assume(err.statusCode).equals(400);
         assume(err.body.message).exists();
@@ -284,7 +284,7 @@ suite('API', function() {
 
     test('fails if no hook exists', async () => {
       await helper.hooks.triggerHook('foo', 'bar', {context: {location: 'Belo Horizonte, MG'}, 
-        firedBy: 'triggerHook'}).then(
+        foo: 'triggerHook'}).then(
         () => { throw new Error('The resource should not exist'); },
         (err) => { assume(err.statusCode).equals(404); });
     });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -234,7 +234,7 @@ suite('API', function() {
     test('returns the last run status for triggerHook', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
       await helper.hooks.triggerHook('foo', 'bar', {location: 'Belo Horizonte, MG', 
-        triggeredBy: 'triggerHook'});
+        firedBy: 'triggerHook'});
       var r1 = await helper.hooks.getHookStatus('foo', 'bar');
       assume(r1).contains('lastFire');
       assume(r1.lastFire.result).is.equal('success');
@@ -251,11 +251,11 @@ suite('API', function() {
     test('should launch task with the given payload', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
       await helper.hooks.triggerHook('foo', 'bar', {location: 'Belo Horizonte, MG', 
-        triggeredBy: 'triggerHook'});
+        firedBy: 'triggerHook'});
       assume(helper.creator.fireCalls).deep.equals([{
         hookGroupId: 'foo',
         hookId: 'bar',
-        payload: {location: 'Belo Horizonte, MG', triggeredBy: 'triggerHook'},
+        payload: {location: 'Belo Horizonte, MG', firedBy: 'triggerHook'},
         options: {},
       }]);
     });
@@ -263,7 +263,7 @@ suite('API', function() {
     test('checking schema validation', async () => {
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
       await helper.hooks.triggerHook('foo', 'bar', {location: 28, 
-        triggeredBy: 'triggerHook'}).then(() => { throw new Error('Location type should be string'); },
+        firedBy: 'triggerHook'}).then(() => { throw new Error('Location type should be string'); },
         (err) => { assume(err.statusCode).equals(400); });
     });
 
@@ -273,7 +273,7 @@ suite('API', function() {
       helper.scopes('hooks:trigger-hook:foo/bar');
       try {
         await helper.hooks.triggerHook('foo', 'bar', {context: {location: 'Belo Horizonte, MG'}, 
-          triggeredBy: 'triggerHook'});
+          firedBy: 'triggerHook'});
       } catch (err) {
         assume(err.statusCode).equals(400);
         assume(err.body.message).exists();
@@ -284,7 +284,7 @@ suite('API', function() {
 
     test('fails if no hook exists', async () => {
       await helper.hooks.triggerHook('foo', 'bar', {context: {location: 'Belo Horizonte, MG'}, 
-        triggeredBy: 'triggerHook'}).then(
+        firedBy: 'triggerHook'}).then(
         () => { throw new Error('The resource should not exist'); },
         (err) => { assume(err.statusCode).equals(404); });
     });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -255,7 +255,7 @@ suite('API', function() {
       assume(helper.creator.fireCalls).deep.equals([{
         hookGroupId: 'foo',
         hookId: 'bar',
-        payload: {firedBy: 'triggerHook', payload: {location: 'Belo Horizonte, MG', foo: 'triggerHook'}},
+        context: {firedBy: 'triggerHook', payload: {location: 'Belo Horizonte, MG', foo: 'triggerHook'}},
         options: {},
       }]);
     });
@@ -318,7 +318,7 @@ suite('API', function() {
       assume(helper.creator.fireCalls).deep.equals([{
         hookGroupId: 'foo',
         hookId: 'bar',
-        payload: {a: 'payload'},
+        context: {a: 'payload'},
         options: {},
       }]);
     });
@@ -362,7 +362,7 @@ suite('API', function() {
       assume(helper.creator.fireCalls).deep.equals([{
         hookGroupId: 'foo',
         hookId: 'bar',
-        payload: payload,
+        context: payload,
         options: {},
       }]);
     });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -255,7 +255,7 @@ suite('API', function() {
       assume(helper.creator.fireCalls).deep.equals([{
         hookGroupId: 'foo',
         hookId: 'bar',
-        payload: {firedBy: 'triggerHook', context: {location: 'Belo Horizonte, MG', foo: 'triggerHook'}},
+        payload: {firedBy: 'triggerHook', payload: {location: 'Belo Horizonte, MG', foo: 'triggerHook'}},
         options: {},
       }]);
     });
@@ -272,7 +272,7 @@ suite('API', function() {
       helper.creator.shouldFail = true; // firing the hook should fail..
       helper.scopes('hooks:trigger-hook:foo/bar');
       try {
-        await helper.hooks.triggerHook('foo', 'bar', {context: {location: 'Belo Horizonte, MG'}, 
+        await helper.hooks.triggerHook('foo', 'bar', {bar: {location: 'Belo Horizonte, MG'}, 
           foo: 'triggerHook'});
       } catch (err) {
         assume(err.statusCode).equals(400);
@@ -283,7 +283,7 @@ suite('API', function() {
     });
 
     test('fails if no hook exists', async () => {
-      await helper.hooks.triggerHook('foo', 'bar', {context: {location: 'Belo Horizonte, MG'}, 
+      await helper.hooks.triggerHook('foo', 'bar', {bar: {location: 'Belo Horizonte, MG'}, 
         foo: 'triggerHook'}).then(
         () => { throw new Error('The resource should not exist'); },
         (err) => { assume(err.statusCode).equals(404); });

--- a/test/scheduler_test.js
+++ b/test/scheduler_test.js
@@ -147,7 +147,7 @@ suite('Scheduler', function() {
       assume(creator.fireCalls).deep.equals([{
         hookGroupId: 'tests',
         hookId: 'test',
-        payload: {},
+        payload: {firedBy: 'schedule'},
         options: {
           taskId: oldTaskId,
           created: new Date(3000, 0, 0, 0, 0, 0, 0),

--- a/test/scheduler_test.js
+++ b/test/scheduler_test.js
@@ -147,7 +147,7 @@ suite('Scheduler', function() {
       assume(creator.fireCalls).deep.equals([{
         hookGroupId: 'tests',
         hookId: 'test',
-        payload: {firedBy: 'schedule'},
+        context: {firedBy: 'schedule'},
         options: {
           taskId: oldTaskId,
           created: new Date(3000, 0, 0, 0, 0, 0, 0),

--- a/test/taskcreator_test.js
+++ b/test/taskcreator_test.js
@@ -144,7 +144,7 @@ suite('MockTaskCreator', function() {
     hook.hookId = 'h';
     await creator.fire(hook, {p: 1}, {o: 1});
     assume(creator.fireCalls).deep.equals([
-      {hookGroupId: 'g', hookId: 'h', payload: {p: 1}, options: {o: 1}},
+      {hookGroupId: 'g', hookId: 'h', context: {p: 1}, options: {o: 1}},
     ]);
   });
 });

--- a/test/taskcreator_test.js
+++ b/test/taskcreator_test.js
@@ -66,9 +66,9 @@ suite('TaskCreator', function() {
   };
 
   test('firing a real task succeeds', async function() {
-    let hook = await createTestHook([], {context:'${context}', triggeredBy:'${triggeredBy}'});
+    let hook = await createTestHook([], {context:'${context}', firedBy:'${firedBy}'});
     let taskId = taskcluster.slugid();
-    let resp = await creator.fire(hook, {context: true, triggeredBy: 'schedule'}, {taskId});
+    let resp = await creator.fire(hook, {context: true, firedBy: 'schedule'}, {taskId});
     assume(resp.status.taskId).equals(taskId);
     assume(resp.status.workerType).equals(hook.task.workerType);
   });
@@ -77,36 +77,36 @@ suite('TaskCreator', function() {
     let hook = await createTestHook([], {context:{
       valueFromContext: {$eval: 'someValue + 13'},
       flattenedDeep: {$flattenDeep: {$eval: 'numbers'}}, 
-      triggeredBy: '${triggeredBy}'},
+      firedBy: '${firedBy}'},
     }); 
     let taskId = taskcluster.slugid();
     let resp = await creator.fire(hook, {
       someValue: 42, 
       numbers: [1, 2, [3, 4], [[5, 6]]],
-      triggeredBy: 'schedule',
+      firedBy: 'schedule',
     }, {taskId});
     let queue = new taskcluster.Queue({credentials: helper.cfg.taskcluster.credentials});
     let task = await queue.task(taskId);
     assume(task.extra).deeply.equals({
-      context: {valueFromContext: 55, flattenedDeep:[1, 2, 3, 4, 5, 6], triggeredBy: 'schedule'},
+      context: {valueFromContext: 55, flattenedDeep:[1, 2, 3, 4, 5, 6], firedBy: 'schedule'},
     });
   });   
 
   test('triggerSchema', async function() {
     let hook = await createTestHook([], {
       env: {DUSTIN_LOCATION: '${location}'},
-      triggeredBy: '${triggeredBy}',
+      firedBy: '${firedBy}',
     }); 
     let taskId = taskcluster.slugid();
     let resp = await creator.fire(hook, {
       location: 'Belo Horizonte, MG',
-      triggeredBy:'schedule',
+      firedBy:'schedule',
     }, {taskId});
     let queue = new taskcluster.Queue({credentials: helper.cfg.taskcluster.credentials});
     let task = await queue.task(taskId);
     assume(task.extra).deeply.equals({
       env: {DUSTIN_LOCATION: 'Belo Horizonte, MG'},
-      triggeredBy:'schedule',
+      firedBy:'schedule',
     });
   });
 


### PR DESCRIPTION
This is nicely broken up into commits, I hope.  Note that 8200a68 is a bugfix: triggering hooks with a payload currently uses the wrong context!

The rest are minor improvements, either improving consistency of terminology ("fire" vs. "trigger", "payload" vs. "context") or defining and adding JSON-e contexts to the firing mechanisms that didn't already have them (`schedule` and `triggerHookWithToken`).