### PR TITLE
Report table metrics like other services

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -38,7 +38,7 @@ var load = loader({
     setup: ({cfg, process, monitor}) => {
       return data.Hook.setup(_.defaults({
         table:        cfg.app.hookTable,
-        monitor:      monitor.prefix('data.hooks'),
+        monitor:      monitor.prefix('table.hooks'),
       }, cfg.azureTable, cfg.taskcluster));
     },
   },

--- a/src/main.js
+++ b/src/main.js
@@ -38,7 +38,7 @@ var load = loader({
     setup: ({cfg, process, monitor}) => {
       return data.Hook.setup(_.defaults({
         table:        cfg.app.hookTable,
-        monitor:      monitor.prefix(cfg.app.hookTable.toLowerCase()),
+        monitor:      monitor.prefix('data.hooks'),
       }, cfg.azureTable, cfg.taskcluster));
     },
   },


### PR DESCRIPTION
Other deployments of this service should pass a different `project` name to monitor... so these won't conflict...

Similar changes in: https://github.com/taskcluster/taskcluster-github/pull/226