### PR TITLE
Remove task-specific schema from hook.task

### DIFF
--- a/schemas/create-hook-request.yml
+++ b/schemas/create-hook-request.yml
@@ -29,7 +29,8 @@ properties:
     default: []
   expires:                {$const: expires}
   deadline:               {$const: deadline}
-  task:                   {$ref: "http://schemas.taskcluster.net/hooks/v1/task-template.json"}
+  task:
+    type:                 object
   triggerSchema:
     type:                 'object'          
     default:              {type: "object", additionalProperties: false}

--- a/schemas/create-hook-request.yml
+++ b/schemas/create-hook-request.yml
@@ -32,7 +32,9 @@ properties:
   task:
     title:                "Task Template"
     description: |
-        Definition of a task embedded in a hook
+      Template for the task definition.  This is rendered using [JSON-e](https://taskcluster.github.io/json-e/)
+      as described in https://docs.taskcluster.net/reference/core/taskcluster-hooks/docs/firing-hooks to produce
+      a task definition that is submitted to the Queue service.
     type:                 object
   triggerSchema:
     type:                 'object'          

--- a/schemas/create-hook-request.yml
+++ b/schemas/create-hook-request.yml
@@ -30,6 +30,9 @@ properties:
   expires:                {$const: expires}
   deadline:               {$const: deadline}
   task:
+    title:                "Task Template"
+    description: |
+        Definition of a task embedded in a hook
     type:                 object
   triggerSchema:
     type:                 'object'          

--- a/schemas/hook-definition.yml
+++ b/schemas/hook-definition.yml
@@ -23,6 +23,9 @@ properties:
   expires:                {$const: expires}
   deadline:               {$const: deadline}
   task:
+    title:                "Task Template"
+    description: |
+      Definition of a task embedded in a hook
     type:                 object
   triggerSchema:
     type:                 object

--- a/schemas/hook-definition.yml
+++ b/schemas/hook-definition.yml
@@ -25,7 +25,9 @@ properties:
   task:
     title:                "Task Template"
     description: |
-      Definition of a task embedded in a hook
+      Template for the task definition.  This is rendered using [JSON-e](https://taskcluster.github.io/json-e/)
+      as described in https://docs.taskcluster.net/reference/core/taskcluster-hooks/docs/firing-hooks to produce
+      a task definition that is submitted to the Queue service.
     type:                 object
   triggerSchema:
     type:                 object

--- a/schemas/hook-definition.yml
+++ b/schemas/hook-definition.yml
@@ -22,7 +22,8 @@ properties:
                           {$ref: "http://schemas.taskcluster.net/hooks/v1/schedule.json"}
   expires:                {$const: expires}
   deadline:               {$const: deadline}
-  task:                   {$ref: "http://schemas.taskcluster.net/hooks/v1/task-template.json"}
+  task:
+    type:                 object
   triggerSchema:
     type:                 object
 additionalProperties:     false

--- a/schemas/task-status.yml
+++ b/schemas/task-status.yml
@@ -47,8 +47,14 @@ properties:
           task-graph scheduler, this is the `taskGraphId`.
         type:           string
         pattern:        {$const: slugid-pattern}
-      deadline:         {$const: deadline}
-      expires:          {$const: expires}
+      deadline:
+        title:          "Deadline"
+        type:           object
+        format:         date-time
+      expires:
+        title:          "Expires"
+        type:           object
+        format:         date-time
       retriesLeft:
         title:          "Retries Left"
         description: |

--- a/schemas/task-status.yml
+++ b/schemas/task-status.yml
@@ -47,14 +47,8 @@ properties:
           task-graph scheduler, this is the `taskGraphId`.
         type:           string
         pattern:        {$const: slugid-pattern}
-      deadline:
-        title:          "Deadline"
-        type:           object
-        format:         date-time
-      expires:
-        title:          "Expires"
-        type:           object
-        format:         date-time
+      deadline:         {$const: deadline}
+      expires:          {$const: expires}
       retriesLeft:
         title:          "Retries Left"
         description: |


### PR DESCRIPTION
This is in reference to Bug 1438019 which requires updating the current schemas in accordance with JSON-e so that hook.task has `type: object`.
