### PR TITLE
Adds test for task property

### DIFF
--- a/test/scheduler_test.js
+++ b/test/scheduler_test.js
@@ -110,17 +110,7 @@ suite('Scheduler', function() {
           owner: 'example@example.com',
           emailOnError: true,
         },
-        task:               {
-          provisionerId: 'no-provisioner',
-          workerType: 'test-worker',
-          metadata: {
-            name: 'test task',
-            description: 'task created by tc-hooks tests',
-            owner: 'taskcluster@mozilla.com',
-            source: 'http://taskcluster.net',
-          },
-          payload: {},
-        },
+        task:               {},
         bindings:           [],
         deadline:           '1 day',
         expires:            '1 day',

--- a/test/taskcreator_test.js
+++ b/test/taskcreator_test.js
@@ -58,7 +58,7 @@ suite('TaskCreator', function() {
     },
     task:               {
       $let: {
-        random: 1
+        random: 1,
       },
     },
   };

--- a/test/taskcreator_test.js
+++ b/test/taskcreator_test.js
@@ -73,6 +73,11 @@ suite('TaskCreator', function() {
       },
       additionalProperties: false,
     },
+    task:               {
+      $let: {
+        random: 1
+      },
+    },
   };
 
   var createTestHook = async function(scopes, extra) {


### PR DESCRIPTION
The PR is in continuation to #77.
Here I have added the tests for hook.task which has its `type` changed to `object` and removed the original tests.
@djmitche could you please review and suggest further changes? Thanks a lot :slightly_smiling_face: 