### PR TITLE
Added test for created, deadline and expires fields

### DIFF
--- a/test/api_test.js
+++ b/test/api_test.js
@@ -42,7 +42,6 @@ suite('API', function() {
     },
   }, dailyHookDef);
 
-
   let setHookLastFire = async (hookGroupId, hookId, lastFire) => {
     let hook = await helper.Hook.load({hookGroupId, hookId}, true);
     await hook.modify((hook) => { hook.lastFire = lastFire; });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -107,7 +107,7 @@ suite('API', function() {
       hook.task.created = r1.nextScheduledDate;
       hook.task.expires = '1 minute';
       hook.task.deadline = '2 minutes';
-      return await.helper.hooks.createHook('foo', 'bar', hookWithTask);
+      return await helper.hooks.createHook('foo', 'bar', hookWithTask);
       assume(new Date(hook.task.expires) - new Date(hook.task.created)).to.equal(60000);
       assume(new Date(hook.task.deadline) - new Date(hook.task.created)).to.equal(120000);
     });


### PR DESCRIPTION
This is in reference to Bug 1437552 : Remove deprecated `deadline` and `expires` fields. 
As a first step I have tried to create test that creates a hook with created, deadline and expires fields.