### PR TITLE
Bug 1442717 - Allow `hookId` and `hookGroupId` in createHook / updateHook

### DIFF
--- a/schemas/create-hook-request.yml
+++ b/schemas/create-hook-request.yml
@@ -4,6 +4,14 @@ description: |
   Definition of a hook that can create tasks at defined times.
 type:                       object
 properties:
+  hookGroupId:
+    type:                 string
+    minLength:            {$const: identifier-min-length}
+    maxLength:            {$const: identifier-max-length}
+    pattern:              {$const: identifier-pattern}
+  hookId:
+    type:                 string
+    maxLength:            255
   metadata:               {$const: metadata}
   schedule:
     # It would be prettier with:

--- a/src/v1.js
+++ b/src/v1.js
@@ -215,6 +215,12 @@ api.declare({
   var hookId    = req.params.hookId;
   var hookDef   = req.body;
 
+  if (req.body.hookGroupId !== null && req.body.hookId !== null) {
+    if (hookGroupId !== req.body.hookGroupId || hookId !== req.body.hookId) {
+      return res.reportError('InputError', 'Hook Ids do not match', {});
+    }
+  }
+
   hookDef = _.defaults({hookGroupId, hookId}, hookDef);
 
   await req.authorize({hookGroupId, hookId});
@@ -277,6 +283,12 @@ api.declare({
   var hookGroupId = req.params.hookGroupId;
   var hookId = req.params.hookId;
   var hookDef = req.body;
+
+  if (req.body.hookGroupId !== null && req.body.hookId !== null) {
+    if (hookGroupId !== req.body.hookGroupId || hookId !== req.body.hookId) {
+      return res.reportError('InputError', 'Hook Ids do not match', {});
+    }
+  }
 
   hookDef = _.defaults({hookGroupId, hookId}, hookDef);
 

--- a/src/v1.js
+++ b/src/v1.js
@@ -215,13 +215,16 @@ api.declare({
   var hookId    = req.params.hookId;
   var hookDef   = req.body;
 
-  if (req.body.hookGroupId !== null && req.body.hookId !== null) {
-    if (hookGroupId !== req.body.hookGroupId || hookId !== req.body.hookId) {
-      return res.reportError('InputError', 'Hook Ids do not match', {});
-    }
+  if (req.body.hookGroupId && hookGroupId !== req.body.hookGroupId) {
+    return res.reportError('InputError', 'Hook Group Ids do not match', {});
   }
 
-  hookDef = _.defaults({hookGroupId, hookId}, hookDef);
+  if (req.body.hookId && hookId !== req.body.hookId) {
+    return res.reportError('InputError', 'Hook Ids do not match', {});
+  }
+
+  hookDef.hookGroupId = hookGroupId;
+  hookDef.hookId = hookId;
 
   await req.authorize({hookGroupId, hookId});
 
@@ -284,13 +287,16 @@ api.declare({
   var hookId = req.params.hookId;
   var hookDef = req.body;
 
-  if (req.body.hookGroupId !== null && req.body.hookId !== null) {
-    if (hookGroupId !== req.body.hookGroupId || hookId !== req.body.hookId) {
-      return res.reportError('InputError', 'Hook Ids do not match', {});
-    }
+  if (req.body.hookGroupId && hookGroupId !== req.body.hookGroupId) {
+    return res.reportError('InputError', 'Hook Group Ids do not match', {});
   }
 
-  hookDef = _.defaults({hookGroupId, hookId}, hookDef);
+  if (req.body.hookId && hookId !== req.body.hookId) {
+    return res.reportError('InputError', 'Hook Ids do not match', {});
+  }
+
+  hookDef.hookGroupId = hookGroupId;
+  hookDef.hookId = hookId;
 
   await req.authorize({hookGroupId, hookId});
 

--- a/src/v1.js
+++ b/src/v1.js
@@ -278,6 +278,8 @@ api.declare({
   var hookId = req.params.hookId;
   var hookDef = req.body;
 
+  hookDef = _.defaults({hookGroupId, hookId}, hookDef);
+
   await req.authorize({hookGroupId, hookId});
 
   var hook = await this.Hook.load({hookGroupId, hookId}, true);


### PR DESCRIPTION
I see that createHook API method already uses _.defaults to set the default value for hookGroupId and hookId if they are not present. If they are present, they are checked using req.authorize(). 

In updateHook API method, I have added the functionality to set default values to these properties if they are not present, and they are being checked by req.authorize() if they are already there.