### PR TITLE
Upgrade the taskcluster-lib-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.17.4",
     "promise": "^8.0.1",
     "taskcluster-client": "^3.1.1",
-    "taskcluster-lib-api": "^6.0.4",
+    "taskcluster-lib-api": "^7.0.0",
     "taskcluster-lib-app": "3.0.0",
     "taskcluster-lib-docs": "^4.1.1",
     "taskcluster-lib-loader": "2.0.0",

--- a/src/v1.js
+++ b/src/v1.js
@@ -30,7 +30,7 @@ var api = new API({
     'https://docs.taskcluster.net/reference/core/taskcluster-hooks/docs/firing-hooks',
     'for more information.',
   ].join('\n'),
-  name: 'HooksAPI',
+  name: 'hooks',
   schemaPrefix:  'http://schemas.taskcluster.net/hooks/v1/',
 });
 

--- a/src/v1.js
+++ b/src/v1.js
@@ -30,6 +30,7 @@ var api = new API({
     'https://docs.taskcluster.net/reference/core/taskcluster-hooks/docs/firing-hooks',
     'for more information.',
   ].join('\n'),
+  name: 'HooksAPI',
   schemaPrefix:  'http://schemas.taskcluster.net/hooks/v1/',
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2493,9 +2493,9 @@ taskcluster-client@^3.0.3, taskcluster-client@^3.1.0, taskcluster-client@^3.1.1:
     slugid "^1.1.0"
     superagent "~3.8.1"
 
-taskcluster-lib-api@^6.0.4:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-6.0.4.tgz#0c1a8cd37ab105caa85a217e6d11818d6a98ecca"
+taskcluster-lib-api@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-7.0.0.tgz#cee45beda5b411df92c9e81b89d5a227039aa01f"
   dependencies:
     ajv "^5.3.0"
     aws-sdk "^2.151.0"


### PR DESCRIPTION
Upgrade to the latest taskcluster-lib-api, add 'name' as parameter
since it is becoming a required parameter.

Related to Bug 1442636