### PR TITLE
run schedule_hooks test all the time

### DIFF
--- a/test/schedule_hooks_test.js
+++ b/test/schedule_hooks_test.js
@@ -3,11 +3,6 @@ suite('bin/schedule-hooks.js', function() {
   var Scheduler         = require('../src/scheduler');
   var helper            = require('./helper');
 
-  // these tests require Azure credentials (for the Hooks table)
-  if (!helper.haveRealCredentials) {
-    this.pending = true;
-  }
-
   test('schedule_hooks launches a scheduler', async () => {
     var scheduler = await helper.load('schedulerNoStart', helper.loadOptions);
     assert(scheduler instanceof Scheduler);


### PR DESCRIPTION
This does not actually require credentials anymore.  At lesat, it works
for me :)