### PR TITLE
Better relay errors from firing

### DIFF
--- a/src/v1.js
+++ b/src/v1.js
@@ -430,8 +430,16 @@ api.declare({
 
   if (resp) {
     return res.reply(resp);
+  } else if (error.requestInfo && error.code) {
+    // handle errors from further API calls specially
+    return res.reportError(
+      'InputError',
+      `While calling queue.createTask: ${error.code}\n\n${error.message}`,
+      {createTask: error.requestInfo});
   } else {
-    return res.reportError('InputError', 'Could not create task: {{error}}',
+    return res.reportError(
+      'InputError',
+      'While firing hook:\n\n{{error}}',
       {error: (error || 'unknown').toString()});
   }
 });


### PR DESCRIPTION
Without this, the error from calling queue.createTask is stringified and
returned, which doesn't come out very well.  With the change, its
message (in Markdown) is prefixed and included verbatim.