### PR TITLE
Bug1430902: Format a invalid error message

### DIFF
--- a/src/v1.js
+++ b/src/v1.js
@@ -204,10 +204,13 @@ builder.declare({
         '{{message}} in {{schedElement}}', {message: err.message, schedElement});
     }
   }
-
+  
   //handle an invalid schema
-  if (!ajv.validateSchema(hookDef.triggerSchema)) {
-    return res.reportError('InputError', 'Invalid Schema', {});
+  let valid = ajv.validateSchema(hookDef.triggerSchema);
+  if (!valid) {
+    return res.reportError('InputError', '{{message}}', {
+      message: ajv.errorsText(ajv.errors, {separator: '; '}),
+    });
   }
 
   // Try to create a Hook entity
@@ -281,8 +284,11 @@ builder.declare({
   }
 
   //handle an invalid schema
-  if (!ajv.validateSchema(hookDef.triggerSchema)) {
-    return res.reportError('InputError', 'Invalid Schema', {});
+  let valid = ajv.validateSchema(hookDef.triggerSchema);
+  if (!valid) {
+    return res.reportError('InputError', '{{message}}', {
+      message: ajv.errorsText(ajv.errors, {separator: '; '}),
+    });
   }
 
   // Attempt to modify properties of the hook

--- a/src/v1.js
+++ b/src/v1.js
@@ -289,9 +289,10 @@ builder.declare({
   if (!hook) {
     return res.reportError('ResourceNotFound', 'No such hook', {});
   }
-
-  //Handle an invalid schema
+  
+  //Handle an invalid schema 
   let valid = ajv.validateSchema(hookDef.triggerSchema);
+  
   if (!valid) {
     const errors = [];
 

--- a/src/v1.js
+++ b/src/v1.js
@@ -205,11 +205,18 @@ builder.declare({
     }
   }
   
-  //handle an invalid schema
+  // Handle an invalid schema
   let valid = ajv.validateSchema(hookDef.triggerSchema);
   if (!valid) {
+    
+    const errors = [];
+
+    for (let index = 0; index < ajv.errors.length; index++) {
+      errors.push(' * Property '+ ajv.errors[index].dataPath + ' ' + ajv.errors[index].message);
+    }
+
     return res.reportError('InputError', '{{message}}', {
-      message: ajv.errorsText(ajv.errors, {separator: '; '}),
+      message: errors.join('\n'),
     });
   }
 
@@ -283,11 +290,17 @@ builder.declare({
     return res.reportError('ResourceNotFound', 'No such hook', {});
   }
 
-  //handle an invalid schema
+  //Handle an invalid schema
   let valid = ajv.validateSchema(hookDef.triggerSchema);
   if (!valid) {
+    const errors = [];
+
+    for (let index = 0; index < ajv.errors.length; index++) {
+      errors.push(' * Property '+ ajv.errors[index].dataPath + ' ' + ajv.errors[index].message);
+    }
+
     return res.reportError('InputError', '{{message}}', {
-      message: ajv.errorsText(ajv.errors, {separator: '; '}),
+      message: errors.join('\n'),
     });
   }
 

--- a/src/v1.js
+++ b/src/v1.js
@@ -216,7 +216,7 @@ builder.declare({
     }
 
     return res.reportError('InputError', '{{message}}', {
-      message: errors.join('\n'),
+      message: 'triggerSchema is not a valid JSON schema:\n' + errors.join('\n'),
     });
   }
 
@@ -301,7 +301,7 @@ builder.declare({
     }
 
     return res.reportError('InputError', '{{message}}', {
-      message: errors.join('\n'),
+      message: 'triggerSchema is not a valid JSON schema:\n' + errors.join('\n'),
     });
   }
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -490,7 +490,7 @@ helper.secrets.mockSuite('api_test.js', ['taskcluster'], function(mock, skipping
         },
       }, hookDef);
       await helper.hooks.createHook('foo', 'bar', nHookDef).then(() => { throw new Error('Expected an error'); },
-        (err) => { debug('Got expected error: %s', err); });
+        (err) => { debug('Got expected error: %s', err); assert(/should be/.test(err.message)); });
     });
 
     test('handle an invalid schema - updateHook', async () => {
@@ -510,8 +510,9 @@ helper.secrets.mockSuite('api_test.js', ['taskcluster'], function(mock, skipping
           additionalProperties: true,
         },
       }, hookDef);
+      await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
       await helper.hooks.updateHook('foo', 'bar', nHookDef).then(() => { throw new Error('Expected an error'); },
-        (err) => { debug('Got expected error: %s', err); });
+        (err) => { debug('Got expected error: %s', err); assert(/should be/.test(err.message)); });
     });
   });
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -489,8 +489,12 @@ helper.secrets.mockSuite('api_test.js', ['taskcluster'], function(mock, skipping
           additionalProperties: true,
         },
       }, hookDef);
-      await helper.hooks.createHook('foo', 'bar', nHookDef).then(() => { throw new Error('Expected an error'); },
-        (err) => { debug('Got expected error: %s', err); assert(/should be/.test(err.message)); });
+      await helper.hooks.createHook('foo', 'bar', nHookDef).then(
+        () => { throw new Error('Expected an error'); },
+        (err) => {
+          debug('Got expected error: %s', err);
+          assert(/should be/.test(err.message));
+        });
     });
 
     test('handle an invalid schema - updateHook', async () => {
@@ -511,8 +515,12 @@ helper.secrets.mockSuite('api_test.js', ['taskcluster'], function(mock, skipping
         },
       }, hookDef);
       await helper.hooks.createHook('foo', 'bar', hookWithTriggerSchema);
-      await helper.hooks.updateHook('foo', 'bar', nHookDef).then(() => { throw new Error('Expected an error'); },
-        (err) => { debug('Got expected error: %s', err); assert(/should be/.test(err.message)); });
+      await helper.hooks.updateHook('foo', 'bar', nHookDef).then(
+        () => { throw new Error('Expected an error'); },
+        (err) => {
+          debug('Got expected error: %s', err);
+          assert(/should be/.test(err.message));
+        });
     });
   });
 


### PR DESCRIPTION
Finally, I think we have a message with found errors delimited by `;`. Anyway,  I am not confident lol