### PR TITLE
Bug 1512512 - remove listener each time it's added

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -160,7 +160,7 @@ helper.withPulse = (mock, skipping) => {
     helper.publisher.on('message', recordMessage);
   });
 
-  suiteTeardown(async function() {
+  teardown(async function() {
     helper.publisher.removeListener('message', recordMessage);
   });
 };


### PR DESCRIPTION
I'm not sure if it's better to add/remove the listener for every test, or to just add it in suiteSetup and remove it in suiteTeardown..